### PR TITLE
Update README and fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ used by users with *Manage Server* permissions
 ### Prerequisites
 
 PronounBot needs a version of nodejs that supports `async/await` and
-postgresql. You'll also need a dicord API key which you can get from
-[here](https://discordapp.com/developers/applications/)
+postgresql. You'll also need a discord API key which you can get from
+[here](https://discord.com/developers/applications/)
 
 ### Installation
 


### PR DESCRIPTION
Updating the README to have the link to the applications page link directly to discord's new url, and fix a typo.